### PR TITLE
fix: missing argument when require 'iconv-lite'

### DIFF
--- a/dist/kit.js
+++ b/dist/kit.js
@@ -2001,7 +2001,7 @@ _.extend(kit, fs, {
                   if (encoding === 'utf8') {
                     return buf.toString();
                   } else {
-                    return kit.requireOptional('iconv-lite').decode(buf, encoding);
+                    return kit.requireOptional('iconv-lite', __dirname).decode(buf, encoding);
                   }
                 } catch (_error) {
                   err = _error;

--- a/lib/kit.coffee
+++ b/lib/kit.coffee
@@ -1812,7 +1812,7 @@ _.extend kit, fs,
 									if encoding == 'utf8'
 										buf.toString()
 									else
-										kit.requireOptional 'iconv-lite'
+										kit.requireOptional 'iconv-lite', __dirname
 										.decode buf, encoding
 								catch err
 									reject err


### PR DESCRIPTION
dir argument is missing