### PR TITLE
Update lodash dependency from 4.17.11 to 4.17.15.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1366,7 +1366,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "inquirer": {
       "version": "6.3.1",
@@ -1607,9 +1608,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -2211,16 +2212,21 @@
           }
         },
         "http-errors": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
           "requires": {
             "depd": "~1.1.2",
-            "inherits": "2.0.3",
+            "inherits": "2.0.4",
             "setprototypeof": "1.1.1",
             "statuses": ">= 1.5.0 < 2",
             "toidentifier": "1.0.0"
           }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "mime": {
           "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/ysmood/nokit",
   "dependencies": {
     "jhash": "0.1.10",
-    "lodash": "4.17.11",
+    "lodash": "4.17.15",
     "noflow": "0.8.11",
     "nofs": "0.12.2",
     "path-to-regexp": "3.0.0",


### PR DESCRIPTION
Hello,

I'm working on on a program analysis tool for some research and I noticed you are using version 4.17.11 of lodash. lodash@4.17.11 has a vulnerability in the defaultsDeep method which is used in this repository in lib/kit.js.

This PR bumps the version of lodash to 4.17.15, the latest version as of this writing. I saw that all of your dependencies are pinned to specific versions and have respected that with this PR.

Let me know if you have any questions or would like to discuss further! Thanks!